### PR TITLE
add babel-runtime to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   "directories": {
     "lib": "lib"
   },
-  "dependencies": {},
+  "dependencies": {
+    "babel-runtime": "^6.26.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mjswensen/themer-vscode.git"


### PR DESCRIPTION
solve `Cannot find module 'babel-runtime/core-js/json/stringify'`
while running `themer -c themer-colors-default -t themer-vscode -o gen`